### PR TITLE
Use backticks for citekey

### DIFF
--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -217,7 +217,7 @@ function getMetadata(item) {
   }
 
   if (getPref("export_citekey")) {
-    metadataString += `* Cite key: ${getCiteKey(item)}\n`;
+    metadataString += `* Cite key: \`${getCiteKey(item)}\`\n`;
   }
 
   if (getPref("export_collections")) {


### PR DESCRIPTION
Surrounds the citekey with backticks in the metadata export
