### PR TITLE
Enable plain attachment links

### DIFF
--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -303,18 +303,20 @@ function getPDFFileLink(attachment) {
 }
 
 function getZoteroAttachments(item) {
+  const linkStylePref = getPref("pdf_link_style");
   let attachmentIDs = item.getAttachments();
   var linksArray = [];
   for (let id of attachmentIDs) {
     let attachment = Zotero.Items.get(id);
     if (attachment.attachmentContentType == "application/pdf") {
-      let linkContent;
-      if (getPref("pdf_link_style") === "zotero") {
-        linkContent = getZoteroPDFLink(attachment);
+      let link;
+      if (linkStylePref === "zotero") {
+        link = `[${attachment.getField("title")}](${getZoteroPDFLink(attachment)})`;
+      } else if (linkStylePref === "plain") {
+        link = `[[${attachment.getField("title")}]]`;
       } else {
-        linkContent = getPDFFileLink(attachment);
+        link = `[${attachment.getField("title")}](${getPDFFileLink(attachment)})`;
       }
-      var link = `[${attachment.getField("title")}](${linkContent})`;
       linksArray.push(link);
     }
   }

--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -312,8 +312,8 @@ function getZoteroAttachments(item) {
       let link;
       if (linkStylePref === "zotero") {
         link = `[${attachment.getField("title")}](${getZoteroPDFLink(attachment)})`;
-      } else if (linkStylePref === "plain") {
-        link = `[[${attachment.getField("title")}]]`;
+      } else if (linkStylePref === "wiki") {
+        link = formatInternalLink(attachment.getField("title"), "wiki");
       } else {
         link = `[${attachment.getField("title")}](${getPDFFileLink(attachment)})`;
       }


### PR DESCRIPTION
If linked PDFs are part of your obsidian attachment folder, just plain wiki-style links could be used too.