### PR TITLE
Add preference defaults so that the itemType, date, and dateAdded fields aren't exported as links

### DIFF
--- a/defaults/preferences/mdnotes.js
+++ b/defaults/preferences/mdnotes.js
@@ -17,6 +17,9 @@ pref("extensions.mdnotes.placeholder.DOI", '{"content":"{{bullet}} DOI: {{field_
 pref("extensions.mdnotes.placeholder.cloudLibrary", '{"content":"{{bullet}} {{field_contents}}"}');
 pref("extensions.mdnotes.placeholder.localLibrary", '{"content":"{{bullet}} {{field_contents}}"}');
 pref("extensions.mdnotes.placeholder.noteContent", '{"content":"{{field_contents}}"}');
+pref("extensions.mdnotes.placeholder.date", '{"field_contents": "{{content}}", "link_style": "no-links"}');
+pref("extensions.mdnotes.placeholder.dateAdded", '{"field_contents": "{{content}}", "link_style": "no-links"}');
+pref("extensions.mdnotes.placeholder.itemType", '{"field_contents": "{{content}}", "link_style": "no-links"}');
 
 pref("extensions.mdnotes.templates.directory", "");
 pref("extensions.mdnotes.templates.include_empty_placeholders", false);


### PR DESCRIPTION
Hi!  I was just helping Ameya (@twilightfades0) with turning off the link generation in the placeholder rendering for `itemType` and a couple other fields, and these settings appear to do that.  I don't know if you *want* to change the default behavior, but if you do, here's a patch...
