### PR TITLE
fix bug on filename when running on Windows

### DIFF
--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -740,11 +740,12 @@ function getFilePath(path, filename) {
 function getObsidianURI(fileName) {
   let uriStart = `obsidian://open?vault=${getPref("obsidian.vault")}&file=`;
 
+  let fileWithPath;
   if(getPref("obsidian.dir").length > 0) {
-    let fileWithPath = getPref("obsidian.dir") + "/" + fileName;
+    fileWithPath = getPref("obsidian.dir") + "/" + fileName;
   }
   else{
-    let fileWithPath = fileName;
+    fileWithPath = fileName;
   }
 
   let encodedFileName = Zotero.File.encodeFilePath(fileWithPath);

--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -739,7 +739,15 @@ function getFilePath(path, filename) {
 
 function getObsidianURI(fileName) {
   let uriStart = `obsidian://open?vault=${getPref("obsidian.vault")}&file=`;
-  let encodedFileName = Zotero.File.encodeFilePath(fileName);
+
+  if(getPref("obsidian.dir").length > 0) {
+    let fileWithPath = getPref("obsidian.dir") + "/" + fileName;
+  }
+  else{
+    let fileWithPath = fileName;
+  }
+
+  let encodedFileName = Zotero.File.encodeFilePath(fileWithPath);
 
   return `${uriStart}${encodedFileName}`;
 }

--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -789,7 +789,8 @@ function getParentItem(item) {
 }
 
 async function addObsidianLink(outputFile, item) {
-  let fileName = outputFile.split("/").pop();
+  let folderSep = Zotero.isWin ? '\\' : '/';
+  let fileName = outputFile.split(folderSep).pop();
   fileName = fileName.split(".")[0];
   let obsidianURI = getObsidianURI(fileName);
   let parentItem = getParentItem(item);

--- a/defaults/preferences/mdnotes.js
+++ b/defaults/preferences/mdnotes.js
@@ -48,3 +48,4 @@ pref("extensions.mdnotes.obsidian.vault", "");
 pref("extensions.mdnotes.obsidian.attach_obsidian_uri", false);
 pref("extensions.mdnotes.obsidian.blocks", false);
 pref("extensions.mdnotes.obsidian.blocks.use_citekey", false);
+pref("extensions.mdnotes.obsidian.dir", "");


### PR DESCRIPTION
There two changes:
1. Add path subfolder to Obsidian vault
2. Fix the floderStep in Windows to get right filename.