### PR TITLE
option to use Zotero rename rule for naming files

### DIFF
--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -366,10 +366,12 @@ function noteToMarkdown(item) {
  * Get an item's base file name from setting's preferences
  */
 function getFileName(item) {
-  let citekeyTitle = getPref("citekey_title");
+  let basenameFormat = getPref("files.basename");
 
-  if (citekeyTitle) {
+  if (basenameFormat === "citekey") {
     return getCiteKey(item);
+  } else if (basenameFormat === "zotero") {
+    return Zotero.Attachments.getFileBaseNameFromItem(item);
   } else {
     if (getPref("link_style") === "wiki") {
       return sanitizeFilename(item.getField("title"));

--- a/content/options.xul
+++ b/content/options.xul
@@ -15,6 +15,7 @@
       <preference id="pref-mdnotes-templates-directory" name="extensions.mdnotes.templates.directory" type="string" />
       <preference id="pref-mdnotes-templates-empty-placeholders" name="extensions.mdnotes.templates.include_empty_placeholders" type="bool" />
 
+      <preference id="pref-mdnotes-files-basename" name="extensions.mdnotes.files.basename" type="string" />
       <preference id="pref-mdnotes-file-conf" name="extensions.mdnotes.file_conf" type="string" />
       <preference id="pref-mdnotes-standalone-menu" name="extensions.mdnotes.standalone_menu" type="bool" />
       <preference id="pref-mdnotes-files-zotero-metadata-prefix" name="extensions.mdnotes.files.zotero.metadata.prefix" type="string" />
@@ -40,7 +41,6 @@
         <tabpanel>
           <!-- General export settings -->
           <vbox>
-            <checkbox id="id-mdnotes-citekey-title" preference="pref-mdnotes-citekey-title" label="&citekey-title;" />
             <checkbox id="id-mdnotes-standalone-menu" preference="pref-mdnotes-standalone-menu" label="&pref-standalone-menu;" />
             <separator />
             <radiogroup id="id-mdnotes-file-group" preference="pref-mdnotes-file-conf">
@@ -97,6 +97,16 @@
         <tabpanel>
           <vbox>
             <!-- Mdnotes files -->
+            <radiogroup id="id-mdnotes-basename-group" preference="pref-mdnotes-files-basename">
+              <caption label="&basename-files;" />
+              <description style="font-size: 10px"> &basename-files-description; </description>
+              <hbox>
+                <radio id="basename-citekey" label="Item citekey" value="citekey" />
+                <radio id="basename-title" label="Item title" value="title" />
+                <radio id="basename-zotero" label="Use Zotero rename rule" value="zotero" />
+              </hbox>
+            </radiogroup>
+            <separator />
             <groupbox>
               <caption label="&mdnotes-files;"/>
               <hbox align="center">

--- a/locale/en-US/mdnotes.dtd
+++ b/locale/en-US/mdnotes.dtd
@@ -3,7 +3,6 @@
 
 <!-- First tab -->
 <!ENTITY mdnotes-export "Export preferences">
-<!ENTITY citekey-title "Use the item's citekey as title?">
 <!ENTITY pref-standalone-menu "Show Standalone Note menu">
 <!ENTITY mdnotes-file-number-label "File organization:">
 <!ENTITY mdnotes-file-number-description "Exporting notes as a single file or in multiple files">
@@ -20,6 +19,8 @@
 <!-- Second tab -->
 <!ENTITY file-names "File names">
 
+<!ENTITY basename-files "File name format">
+<!ENTITY basename-files-description "Choose format of the base file name. Prefixes and suffixes set below will be added to this base name.">
 <!ENTITY mdnotes-files "Mdnotes">
 <!ENTITY standalone-files "Standalone">
 <!ENTITY zotero-metadata-files "Zotero metadata">


### PR DESCRIPTION
This PR replaces `citeKey` pref with `files.basename` pref, and makes it a ternary option by adding "use zotero rename rule" value. This can be further expanded to include more options like re-use the zotfile rule or custom format (in a "printf" style), but this works well enough for me for now. 

Also, the base name formatting is moved to the `Files names` tab in the preferences window, putting it among other naming options. 

Few things that are still missing; 

1. localization other than en-US
2. migration from exiting a `citeKey` value (bool) to new `files.basename` value (string).

Let me know what you think. 