### PR TITLE
(1) add logseq pdf open support (2) typeerror isNote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ docs/.obsidian
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+package-lock.json

--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -171,15 +171,17 @@ function getRelatedItems(item) {
 
       // Get the link content based on settings and item type
       let linkContent;
-      if (!relatedItem.isNote()) {
-        linkContent = getMDNoteFileName(relatedItem);
-      } else if (relatedItem.isNote() && !relatedItem.isTopLevelItem()) {
-        linkContent = getZNoteFileName(relatedItem);
-      } else {
-        linkContent = relatedItem.getField("title");
+      if (relatedItem) {
+        if (!relatedItem.isNote()) {
+          linkContent = getMDNoteFileName(relatedItem);
+        } else if (relatedItem.isNote() && !relatedItem.isTopLevelItem()) {
+          linkContent = getZNoteFileName(relatedItem);
+        } else {
+          linkContent = relatedItem.getField("title");
+        }
+  
+        relatedItemsArray.push(linkContent);
       }
-
-      relatedItemsArray.push(linkContent);
     }
   }
 

--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -293,6 +293,10 @@ function getZoteroAttachments(item) {
         link = `[${attachment.getField("title")}](${getZoteroPDFLink(attachment)})`;
       } else if (linkStylePref === "wiki") {
         link = formatInternalLink(attachment.getField("title"), "wiki");
+      } else if (linkStylePref === "logseq") {
+        link = `[${attachment.getField("title")}](${getZoteroPDFLink(attachment)}) {{zotero-linked-file "${attachment.getField("title")}}}"`;
+      } else if (linkStylePref === "logseq-simple") {
+        link = `[zotero](${getZoteroPDFLink(attachment)}) {{zotero-linked-file "${attachment.getField("title")}"}}`;
       } else {
         link = `[${attachment.getField("title")}](${getPDFFileLink(attachment)})`;
       }


### PR DESCRIPTION
![image](https://github.com/argenos/zotero-mdnotes/assets/32933986/7e90ca61-7211-448d-b105-4bce2104c646)

Add an option to choose pdfattachments format as above.

avail keys for `pdf_link_style` are "zotero", "wiki", "logseq", "logseq-simple". 