### PR TITLE
Fix broken getCiteKey() resulting from recent BBT update

### DIFF
--- a/content/mdnotes.js
+++ b/content/mdnotes.js
@@ -97,12 +97,11 @@ function getDateAdded(item) {
  return simpleISODate(date)
 }
 function getCiteKey(item) {
-  if (typeof Zotero.BetterBibTeX === "object" && Zotero.BetterBibTeX !== null) {
-    var bbtItem = Zotero.BetterBibTeX.KeyManager.get(item.getField("id"));
-    return bbtItem.citekey;
-  }
-
-  return "undefined";
+    try {
+        return item.getField('citationKey');
+    } catch (_) {
+        return undefined;
+    }
 }
 
 function getLocalZoteroLink(item) {
@@ -523,7 +522,7 @@ function replace_wildcards(str, args) {
 
 
 /**
- * 
+ *
  * @param {string} str The string to be replaced
  * @param {Object} args An array with the placeholder name as key and the (formatted) contents as values
  * @returns {string} A string with the placeholders replaced
@@ -728,7 +727,7 @@ async function getZoteroNoteFileContents(item) {
   let fileContents = remove_invalid_placeholders(
     replace_placeholders(template, formattedPlaceholders)
   );
-  
+
   fileContents = replace_wildcards(fileContents, note);
   return { content: fileContents, name: fileName };
 }
@@ -953,10 +952,10 @@ Zotero.Mdnotes =
     async getRegularItemContents(item) {
       let metadata = getItemMetadata(item);
       let template = await readTemplate("Zotero Metadata Template");
-      
+
       // Add custom placeholders
       get_placeholder_contents(template, metadata);
-      
+
       // Add formatting
       let formattedPlaceholders = format_placeholders(metadata);
       let newContents = remove_invalid_placeholders(


### PR DESCRIPTION
A recent change in the BetterBibTex plugin (https://github.com/retorquere/zotero-better-bibtex/commit/63028dcd03ada843d6f55dfd6745bc92d6587ab2, included in version 6.7.132, released on 2023-10-23) renamed 'citekey' to 'citationKey' in the BetterBibTex source code. This broke the ``getCiteKey()`` function in zotero-mdnotes, resulting in exports failing when the 'Use the item's citekey as title' option was enabled by the user (see #224).

This change fixes the problem by updating ``getCiteKey()`` to access 'citationKey' instead of 'citekey' if 'citekey' is undefined.

PS: Sorry about the whitespace changes, those were done by my editor. I can resubmit the pull request without them if you prefer.